### PR TITLE
Remove unused variable

### DIFF
--- a/main.go
+++ b/main.go
@@ -192,7 +192,6 @@ var (
 	whiteListCommits  map[string]bool
 	whiteListBranches []string
 	whiteListRepos    []string
-	fileDiffRegex     *regexp.Regexp
 	sshAuth           *ssh.PublicKeys
 	dir               string
 	maxGo             int


### PR DESCRIPTION
This commit removes the fileDiffRegex variable from main.go

Signed-off-by: Vandewilly Silva <vandewilly.oli.silva@hpe.com>